### PR TITLE
secret_config.py should use 'config.ini' as the fallback CONFIG_PATH

### DIFF
--- a/secret_config.py
+++ b/secret_config.py
@@ -3,9 +3,9 @@ import os
 
 def read():
     """
-    Read secrets/variables from a file mount
+    Read secrets/variables from a file mount, default to './config.ini'
     """
-    CONFIG_PATH = os.getenv('CONFIG_PATH')
+    CONFIG_PATH = os.getenv('CONFIG_PATH', 'config.ini')
     config = configparser.ConfigParser()
     config.read(CONFIG_PATH)
     return config


### PR DESCRIPTION
This should fix the dev environment for testing outside of a docker container according to the README instructions.